### PR TITLE
Fix minor typo from last patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For more information, please read the official [documentation].
 
 You can install KivMob with the following command.
 ```sh
-$ pip3 install kivmob
+$ pip3 install https://github.com/MichaelStott/KivMob/archive/refs/heads/master.zip
 ```
 
 ### Demo Screenshot
@@ -69,17 +69,17 @@ KivMobTest().run()
 Make the following modifications to your buildozer.spec file.
 
 ```
-requirements = python3, kivy, android, jnius, kivmob
+requirements = python3, kivy, android, jnius, https://github.com/MichaelStott/KivMob/archive/refs/heads/master.zip
 ...
 android.permissions = INTERNET, ACCESS_NETWORK_STATE
 android.api = 33
 android.minapi = 21
 android.sdk = 33
 android.ndk = 25b
-android.gradle_dependencies = 'com.google.firebase:firebase-ads:21.4.0'
+android.gradle_dependencies = com.google.firebase:firebase-ads:21.4.0
 android.enable_androidx = True
 p4a.branch = master
-android.meta_data = 'com.google.android.gms.ads.APPLICATION_ID = ca-app-pub-3940256099942544~3347511713'
+android.meta_data = com.google.android.gms.ads.APPLICATION_ID=ca-app-pub-3940256099942544~3347511713
 ```
 
 Finally, build and launch the application.

--- a/demo/buildozer.spec
+++ b/demo/buildozer.spec
@@ -37,7 +37,7 @@ version = 0.1
 
 # (list) Application requirements
 # comma separated e.g. requirements = sqlite3,kivy
-requirements = python3, kivy, jnius, android, kivmob
+requirements = python3, kivy, jnius, android, https://github.com/MichaelStott/KivMob/archive/refs/heads/master.zip
 
 # (str) Custom source folders for requirements
 # Sets custom source for any requirements with recipes
@@ -187,7 +187,7 @@ android.accept_sdk_license = True
 #android.add_assets =
 
 # (list) Gradle dependencies to add
-android.gradle_dependencies = 'com.google.firebase:firebase-ads:21.4.0'
+android.gradle_dependencies = com.google.firebase:firebase-ads:21.4.0
 
 # (bool) Enable AndroidX support. Enable when 'android.gradle_dependencies'
 # contains an 'androidx' package, or any package from Kotlin source.
@@ -239,7 +239,7 @@ android.enable_androidx = True
 #android.wakelock = False
 
 # (list) Android application meta-data to set (key=value format)
-android.meta_data = 'com.google.android.gms.APPLICATION_ID = ca-app-pub-3940256099942544~3347511713'
+android.meta_data = com.google.android.gms.APPLICATION_ID=ca-app-pub-3940256099942544~3347511713
 
 # (list) Android library project to add (will be added in the
 # project.properties automatically.)

--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -8,7 +8,7 @@ KivMob is available for download from the Python Package Index using *pip*:
 
 .. code-block:: sh
 
-    $ pip3 install kivmob
+    $ pip3 install https://github.com/MichaelStott/KivMob/archive/refs/heads/master.zip
 
 Alternatively, you can install it from the source via setup.py
 
@@ -23,18 +23,18 @@ Modify buildozer.spec as such:
 
 .. code-block:: sh
 
-    requirements = python3, kivy, android, jnius, kivmob
+    requirements = python3, kivy, android, jnius, https://github.com/MichaelStott/KivMob/archive/refs/heads/master.zip
     ...
     android.permissions = INTERNET, ACCESS_NETWORK_STATE
     android.api = 33
     android.minapi = 21
     android.sdk = 33
     android.ndk = 25b
-    android.gradle_dependencies = 'com.google.firebase:firebase-ads:21.4.0'
+    android.gradle_dependencies = com.google.firebase:firebase-ads:21.4.0
     android.enable_androidx = True
     p4a.branch = master
     # For test ads, use application ID ca-app-pub-3940256099942544~3347511713
-    android.meta_data = com.google.android.gms.ads.APPLICATION_ID={ADMOB_APP_ID_HERE}
+    android.meta_data = com.google.android.gms.ads.APPLICATION_ID=ADMOB_APP_ID_HERE
 
 Banners
 -----------------


### PR DESCRIPTION
- Removes single quote from build.spec (fix build.gradle': 79: Unexpected input: '{' error)
- pip3 and buildozer always install from git/master