### PR TITLE
Updating quickstart instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ Install [Docker] and pull the official [Buildozer] image (SDK/NDK are cached in 
 $ docker pull kivy/buildozer:latest
 ```
 
-KivMob on Android needs the `kivmob-android-bridge` Maven artifact. Publish it once to your local Maven cache (`~/.m2`):
+KivMob on Android needs the `kivmob-android-bridge` Maven artifact from [GitHub Packages](https://github.com/MichaelStott/KivMob/packages). Create a [classic personal access token](https://github.com/settings/tokens) with `read:packages`, then export your GitHub username and token before building:
 
 ```sh
-$ git clone https://github.com/MichaelStott/KivMob.git /tmp/kivmob-bridge
-$ /tmp/kivmob-bridge/scripts/ci/docker_gradle_bridge.sh :kivmob-android-bridge:publishToMavenLocal
+$ export MAVEN_REPO_USERNAME=YourGitHubUsername
+$ export GITHUB_TOKEN=ghp_...   # or export MAVEN_REPO_PASSWORD instead
 ```
 
 Create a new folder containing `main.py` and `buildozer.spec`.
@@ -56,8 +56,10 @@ $ cd kivmob-quickstart
 $ touch main.py
 $ docker run --rm -it \
     --volume "$HOME/.buildozer":/home/user/.buildozer \
-    --volume "$HOME/.m2":/root/.m2 \
     --volume "$(pwd)":/home/user/hostcwd \
+    -e GITHUB_TOKEN \
+    -e MAVEN_REPO_USERNAME \
+    -e MAVEN_REPO_PASSWORD \
     kivy/buildozer init
 ```
 
@@ -94,17 +96,19 @@ android.ndk = 25b
 android.accept_sdk_license = True
 android.gradle_dependencies = com.google.android.gms:play-services-ads:25.2.0, org.kivmob:kivmob-android-bridge:1.0.0
 android.enable_androidx = True
-android.add_gradle_repositories = mavenLocal()
+android.add_gradle_repositories = "maven { url 'https://maven.pkg.github.com/michaelstott/kivmob'; credentials { username = System.getenv('MAVEN_REPO_USERNAME') ?: ''; password = System.getenv('MAVEN_REPO_PASSWORD') ?: System.getenv('GITHUB_TOKEN') ?: '' } }"
 android.meta_data = com.google.android.gms.ads.APPLICATION_ID=ca-app-pub-3940256099942544~3347511713
 ```
 
-Finally, build and launch the application.
+Finally, build and launch the application (the same `GITHUB_TOKEN` / `MAVEN_REPO_USERNAME` env vars must be set).
 
 ```sh
 $ docker run --rm -it \
     --volume "$HOME/.buildozer":/home/user/.buildozer \
-    --volume "$HOME/.m2":/root/.m2 \
     --volume "$(pwd)":/home/user/hostcwd \
+    -e GITHUB_TOKEN \
+    -e MAVEN_REPO_USERNAME \
+    -e MAVEN_REPO_PASSWORD \
     kivy/buildozer android debug deploy run
 ```
 

--- a/README.md
+++ b/README.md
@@ -35,13 +35,22 @@ $ pip3 install https://github.com/MichaelStott/KivMob/archive/refs/heads/master.
 
 ### Quickstart
 
-Create a new folder containing main.py and buildozer.spec.
+Install [Docker] and pull the official [Buildozer] image (SDK/NDK are cached in `~/.buildozer` on the host).
+
+```sh
+$ docker pull kivy/buildozer:latest
+```
+
+Create a new folder containing `main.py` and `buildozer.spec`.
 
 ```sh
 $ mkdir kivmob-quickstart
 $ cd kivmob-quickstart
 $ touch main.py
-$ buildozer init
+$ docker run --rm -it \
+    --volume "$HOME/.buildozer":/home/user/.buildozer \
+    --volume "$(pwd)":/home/user/hostcwd \
+    kivy/buildozer init
 ```
 
 Copy the following into main.py.
@@ -65,7 +74,7 @@ class KivMobTest(App):
 KivMobTest().run()
 ```
 
-Make the following modifications to your buildozer.spec file.
+Make the following modifications to your `buildozer.spec` file.
 
 ```
 requirements = python3, kivy, android, jnius, https://github.com/MichaelStott/KivMob/archive/refs/heads/master.zip
@@ -75,6 +84,7 @@ android.api = 33
 android.minapi = 21
 android.sdk = 33
 android.ndk = 25b
+android.accept_sdk_license = True
 android.gradle_dependencies = com.google.firebase:firebase-ads:23.6.0
 android.enable_androidx = True
 p4a.branch = master
@@ -84,7 +94,10 @@ android.meta_data = com.google.android.gms.ads.APPLICATION_ID=ca-app-pub-3940256
 Finally, build and launch the application.
 
 ```sh
-$ buildozer android debug deploy run
+$ docker run --rm -it \
+    --volume "$HOME/.buildozer":/home/user/.buildozer \
+    --volume "$(pwd)":/home/user/hostcwd \
+    kivy/buildozer android debug deploy run
 ```
 
 ### Other 
@@ -95,6 +108,7 @@ KivMob is an open source project not associated with AdMob. Please abide by thei
 [Google AdMob]: <https://www.google.com/admob/>
 [Kivy]: <https://kivy.org/>
 [Buildozer]: <https://github.com/kivy/buildozer>
+[Docker]: <https://docs.docker.com/>
 [documentation]: <http://kivmob.com>
 
 <!-- App showcase author links -->

--- a/README.md
+++ b/README.md
@@ -41,12 +41,7 @@ Install [Docker] and pull the official [Buildozer] image (SDK/NDK are cached in 
 $ docker pull kivy/buildozer:latest
 ```
 
-KivMob on Android needs the `kivmob-android-bridge` Maven artifact from [GitHub Packages](https://github.com/MichaelStott/KivMob/packages). Create a [classic personal access token](https://github.com/settings/tokens) with `read:packages`, then export your GitHub username and token before building:
-
-```sh
-$ export MAVEN_REPO_USERNAME=YourGitHubUsername
-$ export GITHUB_TOKEN=ghp_...   # or export MAVEN_REPO_PASSWORD instead
-```
+KivMob on Android needs the `kivmob-android-bridge` Maven artifact, published to [GitHub Packages](https://github.com/MichaelStott/KivMob/packages) from this repository.
 
 Create a new folder containing `main.py` and `buildozer.spec`.
 
@@ -57,9 +52,6 @@ $ touch main.py
 $ docker run --rm -it \
     --volume "$HOME/.buildozer":/home/user/.buildozer \
     --volume "$(pwd)":/home/user/hostcwd \
-    -e GITHUB_TOKEN \
-    -e MAVEN_REPO_USERNAME \
-    -e MAVEN_REPO_PASSWORD \
     kivy/buildozer init
 ```
 
@@ -96,19 +88,16 @@ android.ndk = 25b
 android.accept_sdk_license = True
 android.gradle_dependencies = com.google.android.gms:play-services-ads:25.2.0, org.kivmob:kivmob-android-bridge:1.0.0
 android.enable_androidx = True
-android.add_gradle_repositories = "maven { url 'https://maven.pkg.github.com/michaelstott/kivmob'; credentials { username = System.getenv('MAVEN_REPO_USERNAME') ?: ''; password = System.getenv('MAVEN_REPO_PASSWORD') ?: System.getenv('GITHUB_TOKEN') ?: '' } }"
+android.add_gradle_repositories = "maven { url 'https://maven.pkg.github.com/michaelstott/kivmob' }"
 android.meta_data = com.google.android.gms.ads.APPLICATION_ID=ca-app-pub-3940256099942544~3347511713
 ```
 
-Finally, build and launch the application (the same `GITHUB_TOKEN` / `MAVEN_REPO_USERNAME` env vars must be set).
+Finally, build and launch the application.
 
 ```sh
 $ docker run --rm -it \
     --volume "$HOME/.buildozer":/home/user/.buildozer \
     --volume "$(pwd)":/home/user/hostcwd \
-    -e GITHUB_TOKEN \
-    -e MAVEN_REPO_USERNAME \
-    -e MAVEN_REPO_PASSWORD \
     kivy/buildozer android debug deploy run
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ Install [Docker] and pull the official [Buildozer] image (SDK/NDK are cached in 
 $ docker pull kivy/buildozer:latest
 ```
 
+KivMob on Android needs the `kivmob-android-bridge` Maven artifact. Publish it once to your local Maven cache (`~/.m2`):
+
+```sh
+$ git clone https://github.com/MichaelStott/KivMob.git /tmp/kivmob-bridge
+$ /tmp/kivmob-bridge/scripts/ci/docker_gradle_bridge.sh :kivmob-android-bridge:publishToMavenLocal
+```
+
 Create a new folder containing `main.py` and `buildozer.spec`.
 
 ```sh
@@ -49,6 +56,7 @@ $ cd kivmob-quickstart
 $ touch main.py
 $ docker run --rm -it \
     --volume "$HOME/.buildozer":/home/user/.buildozer \
+    --volume "$HOME/.m2":/root/.m2 \
     --volume "$(pwd)":/home/user/hostcwd \
     kivy/buildozer init
 ```
@@ -80,14 +88,13 @@ Make the following modifications to your `buildozer.spec` file.
 requirements = python3, kivy, android, jnius, https://github.com/MichaelStott/KivMob/archive/refs/heads/master.zip
 ...
 android.permissions = INTERNET, ACCESS_NETWORK_STATE
-android.api = 33
-android.minapi = 21
-android.sdk = 33
+android.api = 35
+android.minapi = 23
 android.ndk = 25b
 android.accept_sdk_license = True
-android.gradle_dependencies = com.google.firebase:firebase-ads:23.6.0
+android.gradle_dependencies = com.google.android.gms:play-services-ads:25.2.0, org.kivmob:kivmob-android-bridge:1.0.0
 android.enable_androidx = True
-p4a.branch = master
+android.add_gradle_repositories = mavenLocal()
 android.meta_data = com.google.android.gms.ads.APPLICATION_ID=ca-app-pub-3940256099942544~3347511713
 ```
 
@@ -96,6 +103,7 @@ Finally, build and launch the application.
 ```sh
 $ docker run --rm -it \
     --volume "$HOME/.buildozer":/home/user/.buildozer \
+    --volume "$HOME/.m2":/root/.m2 \
     --volume "$(pwd)":/home/user/hostcwd \
     kivy/buildozer android debug deploy run
 ```


### PR DESCRIPTION
Kivy builds now favor the docker version of buildozer, so opting for that in the quickstart. 